### PR TITLE
use simple 4 digit integer for attended pass

### DIFF
--- a/krfb/invitationsrfbserver.cpp
+++ b/krfb/invitationsrfbserver.cpp
@@ -110,7 +110,7 @@ void InvitationsRfbServer::toggleUnattendedAccess(bool allow)
 
 InvitationsRfbServer::InvitationsRfbServer()
 {
-    m_desktopPassword = readableRandomString(4) + QLatin1Char('-') + readableRandomString(3);
+    m_desktopPassword = readableRandomFourDigits();
     m_unattendedPassword = readableRandomString(4) + QLatin1Char('-') + readableRandomString(3);
     KConfigGroup krfbConfig(KSharedConfig::openConfig(),"Security");
     m_allowUnattendedAccess = krfbConfig.readEntry(
@@ -205,6 +205,19 @@ void InvitationsRfbServer::walletOpened(bool opened)
         }
 
     }
+}
+
+// a random string made up of numbers for easy readability
+// based on KRandom::random()
+QString InvitationsRfbServer::readableRandomFourDigits()
+{
+    int r = KRandom::random();
+    while (r < 1000) {
+        r = KRandom::random();
+    }
+    QString str = QString::number(r);
+    str.resize(4);
+    return str;
 }
 
 // a random string that doesn't contain i, I, o, O, 1, l, 0

--- a/krfb/invitationsrfbserver.h
+++ b/krfb/invitationsrfbserver.h
@@ -68,6 +68,7 @@ private:
     QString m_unattendedPassword;
     KWallet::Wallet *m_wallet;
 
+    QString readableRandomFourDigits();
     QString readableRandomString(int);
     Q_DISABLE_COPY(InvitationsRfbServer)
 };


### PR DESCRIPTION
Users reading out multi char/case is too hard over the phone.

This only affects the attended password option, so the second factor auth (user clicking Accept) is still required even if the 4 digits were guessed.